### PR TITLE
Adds support for removing a list of users from TestFlight.

### DIFF
--- a/lib/fastlane/plugin/clean_testflight_testers/actions/clean_testflight_testers_action.rb
+++ b/lib/fastlane/plugin/clean_testflight_testers/actions/clean_testflight_testers_action.rb
@@ -19,23 +19,40 @@ module Fastlane
         all_testers = Spaceship::TestFlight::Tester.all(app_id: app_id)
         counter = 0
 
-        all_testers.each do |current_tester|
-          days_since_status_change = (Time.now - current_tester.status_mod_time) / 60.0 / 60.0 / 24.0
+        testers = params[:testers]
 
-          if current_tester.status == "invited"
-            if days_since_status_change > params[:days_of_inactivity]
-              remove_tester(current_tester, app_id, params[:dry_run]) # user got invited, but never installed a build... why would you do that?
-              counter += 1
+        if testers.nil? == false
+            # Check to make sure that the requested tester exists, first.
+            all_testers_emails = all_testers.map { |t| t.email }
+
+            testers.each do |tester|
+                UI.user_error!("Couldn't find the requested tester '#{tester}' for app '#{params[:app_identifier]}' on iTunes Connect") unless all_testers_emails.include? tester
+
+                # Get the tester via index from the mapping above,
+                # then use that index to find and remove the tester from iTC.
+                index = all_testers_emails.index(tester)
+
+                remove_tester(all_testers[index], app_id, params[:dry_run])
             end
-          else
-            # We don't really have a good way to detect whether the user is active unfortunately
-            # So we can just delete users that had no sessions
-            if days_since_status_change > params[:days_of_inactivity] && current_tester.session_count == 0
-              # User had no sessions in the last e.g. 30 days, let's get rid of them
-              remove_tester(current_tester, app_id, params[:dry_run])
-              counter += 1
+        else
+            all_testers.each do |current_tester|
+              days_since_status_change = (Time.now - current_tester.status_mod_time) / 60.0 / 60.0 / 24.0
+
+              if current_tester.status == "invited"
+                if days_since_status_change > params[:days_of_inactivity]
+                  remove_tester(current_tester, app_id, params[:dry_run]) # user got invited, but never installed a build... why would you do that?
+                  counter += 1
+                end
+              else
+                # We don't really have a good way to detect whether the user is active unfortunately
+                # So we can just delete users that had no sessions
+                if days_since_status_change > params[:days_of_inactivity] && current_tester.session_count == 0
+                  # User had no sessions in the last e.g. 30 days, let's get rid of them
+                  remove_tester(current_tester, app_id, params[:dry_run])
+                  counter += 1
+                end
+              end
             end
-          end
         end
 
         if params[:dry_run]
@@ -72,10 +89,10 @@ module Fastlane
 
         [
           FastlaneCore::ConfigItem.new(key: :username,
-                                     short_option: "-u",
-                                     env_name: "CLEAN_TESTFLIGHT_TESTERS_USERNAME",
-                                     description: "Your Apple ID Username",
-                                     default_value: user),
+                                       short_option: "-u",
+                                       env_name: "CLEAN_TESTFLIGHT_TESTERS_USERNAME",
+                                       description: "Your Apple ID Username",
+                                       default_value: user),
           FastlaneCore::ConfigItem.new(key: :app_identifier,
                                        short_option: "-a",
                                        env_name: "CLEAN_TESTFLIGHT_TESTERS_APP_IDENTIFIER",
@@ -102,20 +119,27 @@ module Fastlane
                                          ENV["FASTLANE_ITC_TEAM_NAME"] = value.to_s
                                        end),
           FastlaneCore::ConfigItem.new(key: :days_of_inactivity,
-                                     short_option: "-k",
-                                     env_name: "CLEAN_TESTFLIGHT_TESTERS_WAIT_PROCESSING_INTERVAL",
-                                     description: "Numbers of days a tester has to be inactive for (no build uses) for them to be removed",
-                                     default_value: 30,
-                                     type: Integer,
-                                     verify_block: proc do |value|
-                                       UI.user_error!("Please enter a valid positive number of days") unless value.to_i > 0
-                                     end),
+                                       short_option: "-k",
+                                       env_name: "CLEAN_TESTFLIGHT_TESTERS_WAIT_PROCESSING_INTERVAL",
+                                       description: "Numbers of days a tester has to be inactive for (no build uses) for them to be removed",
+                                       default_value: 30,
+                                       type: Integer,
+                                       verify_block: proc do |value|
+                                         UI.user_error!("Please enter a valid positive number of days") unless value.to_i > 0
+                                       end),
+          FastlaneCore::ConfigItem.new(key: :testers,
+                                       short_option: "-t",
+                                       env_name: "CLEAN_TESTFLIGHT_TESTERS_TESTERS",
+                                       description: "A list of specific testers to remove, this disregards `days_of_inactivity` (optional)",
+                                       type: Array,
+                                       optional: true,
+                                       default_value: nil),
           FastlaneCore::ConfigItem.new(key: :dry_run,
-                                     short_option: "-d",
-                                     env_name: "CLEAN_TESTFLIGHT_TESTERS_DRY_RUN",
-                                     description: "Only print inactive users, don't delete them",
-                                     default_value: false,
-                                     is_string: false)
+                                       short_option: "-d",
+                                       env_name: "CLEAN_TESTFLIGHT_TESTERS_DRY_RUN",
+                                       description: "Only print inactive users, don't delete them",
+                                       default_value: false,
+                                       is_string: false)
         ]
       end
 


### PR DESCRIPTION
This adds an option to pass in an array of emails that you want to remove from TestFlight.

I thought about this piece of functionality since I often get people who use Apple's "Unsubscribe" reply as an effort to remove themselves from a TestFlight beta. Rather than go on Apple's website to remove the tester, I decided to add this as an optional param in the cleanup plugin if people knew which emails they wanted to remove.