### PR TITLE
Use ConnectAPI

### DIFF
--- a/lib/fastlane/plugin/clean_testflight_testers/actions/clean_testflight_testers_action.rb
+++ b/lib/fastlane/plugin/clean_testflight_testers/actions/clean_testflight_testers_action.rb
@@ -4,39 +4,44 @@ module Fastlane
       def self.run(params)
         require 'spaceship'
 
-        UI.message("Login to iTunes Connect (#{params[:username]})")
-        Spaceship::Tunes.login(params[:username])
+        app_identifier = params[:app_identifier]
+        username = params[:username]
+
+        UI.message("Login to iTunes Connect (#{username})")
+        Spaceship::Tunes.login(username)
         Spaceship::Tunes.select_team
         UI.message("Login successful")
 
         UI.message("Fetching all TestFlight testers, this might take a few minutes, depending on the number of testers")
 
         # Convert from bundle identifier to app ID
-        spaceship_app ||= Spaceship::Application.find(params[:app_identifier])
-        UI.user_error!("Couldn't find app '#{params[:app_identifier]}' on the account of '#{params[:username]}' on iTunes Connect") unless spaceship_app
-        app_id = spaceship_app.apple_id
+        spaceship_app ||= Spaceship::ConnectAPI::App.find(app_identifier)
+        UI.user_error!("Couldn't find app '#{app_identifier}' on the account of '#{username}' on iTunes Connect") unless spaceship_app
 
-        all_testers = Spaceship::TestFlight::Tester.all(app_id: app_id)
+        all_testers = spaceship_app.get_beta_testers(includes: "betaTesterMetrics", limit: 200)
         counter = 0
 
         all_testers.each do |current_tester|
-          days_since_status_change = (Time.now - current_tester.status_mod_time) / 60.0 / 60.0 / 24.0
+          tester_metrics = current_tester.beta_tester_metrics.first
 
-          if current_tester.status == "invited"
+          time = Time.parse(tester_metrics.last_modified_date)
+          days_since_status_change = (Time.now - time) / 60.0 / 60.0 / 24.0
+
+          if tester_metrics.beta_tester_state == "INVITED"
             if days_since_status_change > params[:days_of_inactivity]
-              remove_tester(current_tester, app_id, params[:dry_run]) # user got invited, but never installed a build... why would you do that?
+              remove_tester(current_tester, spaceship_app, params[:dry_run]) # user got invited, but never installed a build... why would you do that?
               counter += 1
             end
           else
             # We don't really have a good way to detect whether the user is active unfortunately
             # So we can just delete users that had no sessions
-            if days_since_status_change > params[:days_of_inactivity] && current_tester.session_count == 0
+            if days_since_status_change > params[:days_of_inactivity] && tester_metrics.session_count == 0
               # User had no sessions in the last e.g. 30 days, let's get rid of them
-              remove_tester(current_tester, app_id, params[:dry_run])
+              remove_tester(current_tester, spaceship_app, params[:dry_run])
               counter += 1
-            elsif params[:oldest_build_allowed] && current_tester.latest_install_info["latestInstalledVersion"].to_i > 0 && current_tester.latest_install_info["latestInstalledVersion"].to_i < params[:oldest_build_allowed]
+            elsif params[:oldest_build_allowed] && tester_metrics.installed_cf_bundle_short_version_string.to_i > 0 && tester_metrics.installed_cf_bundle_short_version_string.to_i < params[:oldest_build_allowed]
               # User has a build that is too old, let's get rid of them
-              remove_tester(current_tester, app_id, params[:dry_run])
+              remove_tester(current_tester, spaceship_app, params[:dry_run])
               counter += 1
             end
           end
@@ -49,12 +54,12 @@ module Fastlane
         end
       end
 
-      def self.remove_tester(tester, app_id, dry_run)
+      def self.remove_tester(tester, app, dry_run)
         if dry_run
-          UI.message("TestFlight tester #{tester.email} seems to be inactive for app ID #{app_id}")
+          UI.message("TestFlight tester #{tester.email} seems to be inactive for app ID #{app.id}")
         else
-          UI.message("Removing tester #{tester.email} due to inactivity from app ID #{app_id}...")
-          tester.remove_from_app!(app_id: app_id)
+          UI.message("Removing tester #{tester.email} due to inactivity from app ID #{app.id}...")
+          tester.delete_from_apps(apps: [app])
         end
       end
 


### PR DESCRIPTION
This PR makes usage of Spaceship's `ConnectAPI` instead of the legacy `TestFlight` class.