### PR TITLE
[FIX] Version Number swapped with Build Number

### DIFF
--- a/lib/fastlane/plugin/clean_testflight_testers/actions/clean_testflight_testers_action.rb
+++ b/lib/fastlane/plugin/clean_testflight_testers/actions/clean_testflight_testers_action.rb
@@ -39,7 +39,7 @@ module Fastlane
               # User had no sessions in the last e.g. 30 days, let's get rid of them
               remove_tester(current_tester, spaceship_app, params[:dry_run])
               counter += 1
-            elsif params[:oldest_build_allowed] && tester_metrics.installed_cf_bundle_short_version_string.to_i > 0 && tester_metrics.installed_cf_bundle_short_version_string.to_i < params[:oldest_build_allowed]
+            elsif params[:oldest_build_allowed] && tester_metrics.installed_cf_bundle_version.to_i > 0 && tester_metrics.installed_cf_bundle_version.to_i < params[:oldest_build_allowed]
               # User has a build that is too old, let's get rid of them
               remove_tester(current_tester, spaceship_app, params[:dry_run])
               counter += 1

--- a/lib/fastlane/plugin/clean_testflight_testers/version.rb
+++ b/lib/fastlane/plugin/clean_testflight_testers/version.rb
@@ -1,5 +1,5 @@
 module Fastlane
   module CleanTestflightTesters
-    VERSION = "0.3.0"
+    VERSION = "0.3.1"
   end
 end


### PR DESCRIPTION
Build Number is `installed_cf_bundle_version` - Apple Docs [CFBundleVersion](https://developer.apple.com/documentation/bundleresources/information_property_list/cfbundleversion)
Version Number is `installed_cf_bundle_short_version_string` - Apple Docs [CFBundleShortVersionString](https://developer.apple.com/documentation/bundleresources/information_property_list/cfbundleshortversionstring)


So if my app is `2.3.0 (11)`
```ruby
installed_cf_bundle_version == 11
installed_cf_bundle_short_version_string == "2.3.0"
```